### PR TITLE
fix: resolve directory to absolute path at init time

### DIFF
--- a/gxtb_ase/calculator.py
+++ b/gxtb_ase/calculator.py
@@ -98,6 +98,11 @@ class GxTB(FileIOCalculator):
         **kwargs : dict
             Additional parameters: charge, spin, numerical_grad, etc.
         """
+        # Resolve directory to absolute path at init time so that files are
+        # written relative to the caller's working directory, not wherever
+        # the process cwd happens to be at calculation time.
+        directory = str(Path(directory).resolve())
+
         # g-xTB config for files
         self.tmpdir = tmpdir
         self.keep_files = keep_files


### PR DESCRIPTION
When the process working directory changes between calculator creation and calculation time (e.g., via `uv --directory`), relative `directory` paths produce files in the wrong location. This resolves the `directory` to an absolute path in `__init__`, so the working directory at call time no longer matters.